### PR TITLE
Transmit NEC with repeats

### DIFF
--- a/components/nec_light/nec_light.cpp
+++ b/components/nec_light/nec_light.cpp
@@ -162,7 +162,7 @@ namespace esphome {
 
     void NecLightOutput::send_nec_(uint16_t address, uint16_t command) {
       auto transmit = this->emitter_->transmit();
-      remote_base::NECData data{address, command};
+      remote_base::NECData data{address, command, 1};
       remote_base::NECProtocol().encode(transmit.get_data(), data);
       transmit.perform();
     }

--- a/components/sara_light/sara_light.cpp
+++ b/components/sara_light/sara_light.cpp
@@ -169,7 +169,7 @@ namespace esphome {
 
       void SaraLightOutput::send_nec_(uint16_t address, uint16_t command) {
           auto transmit = this->emitter_->transmit();
-          remote_base::NECData data{address, command};
+          remote_base::NECData data{address, command, 1};
           remote_base::NECProtocol().encode(transmit.get_data(), data);
           transmit.perform();
       }


### PR DESCRIPTION
Empirically, 0 repeats results in it sending just the address and not the command, at least on libretiny/beken. With 1 repeat, it sends the entire message once. This could either be a platform issue or just an upstream change, but even if on other platforms it does include a additional repeat this shouldn't harm anything.